### PR TITLE
allow.chflags required for running in jail

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ allow.mount
 allow.mount.nullfs
 allow.mount.tmpfs
 allow.mount.devfs
+allow.chflags
 ```
 (Courtesy of Dewayne Geraghty)
 


### PR DESCRIPTION
Add `allow.chflags` to the list of properties required in jail.conf to run synth in a jail.