### PR TITLE
Make watchdog configurable via 'synth configure'

### DIFF
--- a/src/actions.adb
+++ b/src/actions.adb
@@ -124,7 +124,7 @@ package body Actions is
       dashes : constant String (1 .. 79) := (others => LAT.Equals_Sign);
       indent : constant String (1 ..  3) := (others => LAT.Space);
       subtype ofield is String (1 .. 30);
-      type option is range 1 .. 14;
+      type option is range 1 .. 15;
       type desc_type is array (option) of ofield;
       descriptions : desc_type :=
          (
@@ -142,7 +142,8 @@ package body Actions is
           "[K] Use tmpfs for work area   ",
           "[L] Use tmpfs for /usr/local  ",
           "[M] Display using ncurses     ",
-          "[N] Fetch prebuilt packages   ");
+          "[N] Fetch prebuilt packages   ",
+          "[O] Enable watchdog           ");
 
       optX1A : constant String := "[>]   Switch/create profiles " &
                                          "(changes discarded)";
@@ -205,13 +206,15 @@ package body Actions is
                        origbool := PM.configuration.avec_ncurses;
             when 14 => nextbool := dupe.defer_prebuilt;
                        origbool := PM.configuration.defer_prebuilt;
+            when 15 => nextbool := dupe.enable_watchdog;
+                       origbool := PM.configuration.enable_watchdog;
          end case;
          case opt is
             when 1 .. 8   => equivalent := JT.equivalent (orig, next);
                              show := next;
             when 9 .. 10  => equivalent := (orignat = nextnat);
                              show := JT.int2text (Integer (nextnat));
-            when 11 .. 14 => equivalent := (origbool = nextbool);
+            when 11 .. 15 => equivalent := (origbool = nextbool);
                              show := JT.bool2text (nextbool);
          end case;
          if equivalent then
@@ -275,6 +278,7 @@ package body Actions is
             when 12 => dupe.tmpfs_localbase := new_value;
             when 13 => dupe.avec_ncurses := new_value;
             when 14 => dupe.defer_prebuilt := new_value;
+            when 15 => dupe.enable_watchdog := new_value;
             when others => raise menu_error
                  with "Illegal value : " & opt'Img;
          end case;
@@ -575,10 +579,10 @@ package body Actions is
                when 'i' .. 'j' =>
                   change_positive_option (option (ascii - 96));
                   exit;
-               when 'K' .. 'N' =>
+               when 'K' .. 'O' =>
                   change_boolean_option (option (ascii - 64));
                   exit;
-               when 'k' .. 'n' =>
+               when 'k' .. 'o' =>
                   change_boolean_option (option (ascii - 96));
                   exit;
                when '>' =>

--- a/src/parameters.adb
+++ b/src/parameters.adb
@@ -216,11 +216,12 @@ package body Parameters is
          raise bad_opsys;
       end if;
 
-      res.dir_options    := extract_string (profile, Field_13, std_options);
-      res.dir_system     := extract_string (profile, Field_14, std_sysbase);
-      res.avec_ncurses   := extract_boolean (profile, Field_15, True);
-      res.defer_prebuilt := extract_boolean (profile, Field_16, False);
-      res.profile        := JT.SUS (profile);
+      res.dir_options     := extract_string (profile, Field_13, std_options);
+      res.dir_system      := extract_string (profile, Field_14, std_sysbase);
+      res.avec_ncurses    := extract_boolean (profile, Field_15, True);
+      res.defer_prebuilt  := extract_boolean (profile, Field_16, False);
+      res.enable_watchdog := extract_boolean (profile, Field_17, True);
+      res.profile         := JT.SUS (profile);
       return res;
    end load_specific_profile;
 
@@ -423,7 +424,8 @@ package body Parameters is
         Field_10 & TFS (configuration.tmpfs_workdir) &
         Field_11 & TFS (configuration.tmpfs_localbase) &
         Field_15 & TFS (configuration.avec_ncurses) &
-        Field_16 & TFS (configuration.defer_prebuilt);
+        Field_16 & TFS (configuration.defer_prebuilt) &
+        Field_17 & TFS (configuration.enable_watchdog);
    end generated_section;
 
 
@@ -615,6 +617,7 @@ package body Parameters is
       result.tmpfs_localbase := enough_memory (result.num_builders);
       result.avec_ncurses    := True;
       result.defer_prebuilt  := False;
+      result.enable_watchdog := True;
 
       write_blank_section (section => new_profile);
 

--- a/src/parameters.ads
+++ b/src/parameters.ads
@@ -32,6 +32,7 @@ package Parameters is
          tmpfs_localbase : Boolean;
          avec_ncurses    : Boolean;
          defer_prebuilt  : Boolean;
+         enable_watchdog : Boolean;
       end record;
 
    configuration  : configuration_record;
@@ -116,6 +117,7 @@ private
    Field_14 : constant String := "Directory_system";
    Field_15 : constant String := "Display_with_ncurses";
    Field_16 : constant String := "leverage_prebuilt";
+   Field_17 : constant String := "enable_watchdog";
 
    global_01 : constant String := "profile_selected";
 
@@ -147,3 +149,4 @@ private
    procedure mkdirp_from_file (filename : String);
 
 end Parameters;
+

--- a/src/portscan-buildcycle.adb
+++ b/src/portscan-buildcycle.adb
@@ -701,7 +701,7 @@ package body PortScan.Buildcycle is
       status      : Unix.process_exit;
       lock_lines  : Natural;
       quartersec  : one_minute := one_minute'First;
-      hangmonitor : constant Boolean := True;
+      hangmonitor : Boolean := PM.configuration.enable_watchdog;
       synthexec   : constant String := host_localbase & "/libexec/synthexec";
       truecommand : constant String := synthexec & " " &
                              log_name (trackers (id).seq_id) & " " & command;


### PR DESCRIPTION
I know this isn't entirely ideal (from your perspective), but I have a couple of systems running FreeBSD -CURRENT that suck and tend to stall for large-ish amounts of time while building ports, but it is still making progress.

Rather than take the potentially large amounts of time to tune the watchdog timeouts (for each machine), I'd like to just disable the watchdog. The runtime performance of these machines is not critical, but it actually building the up-to-date packages kind of is. Having this as a 'configure' option that defaults to 'enabled' seems like a good way to handle this.

Consideration of this PR would be much appreciated. =) For your own information, the ports these machines struggle with the most are lang/gcc6, lang/gcc6-aux, and devel/avr-gcc. Nothing else really gets caught by the watchdog.