### PR TITLE
set the time limit for build depends to 8 minute

### DIFF
--- a/src/portscan-buildcycle-ports.adb
+++ b/src/portscan-buildcycle-ports.adb
@@ -151,7 +151,7 @@ package body PortScan.Buildcycle.Ports is
          when extract          => base := 20;
          when patch_depends    => base := 3;
          when patch            => base := 3;
-         when build_depends    => base := 5;
+         when build_depends    => base := 11;   -- for texlive
          when lib_depends      => base := 5;
          when configure        => base := 15;
          when build            => base := 25;   --  for gcc linking, tex


### PR DESCRIPTION
The default settings for watchdog during build depends phase is at 5 minute, but this can be in some case not enough when extracting texlive-texmf for example. So let's rise it to 25 minute