### PR TITLE
Add armv6 platform recognition

### DIFF
--- a/src/replicant-platform.adb
+++ b/src/replicant-platform.adb
@@ -187,6 +187,8 @@ package body Replicant.Platform is
            arch (arch'First .. arch'First + 4) = "AMD64"
          then
             return "x86:64";
+         elsif arch (arch'First .. arch'First + 2) = "ARM" then
+            return "armv6:32:el:eabi:softfp";
          elsif arch = "Intel 80386" then
             return "x86:32";
          else
@@ -200,6 +202,8 @@ package body Replicant.Platform is
            arch (arch'First .. arch'First + 4) = "AMD64"
          then
             return "amd64";
+         elsif arch (arch'First .. arch'First + 2) = "ARM" then
+            return "armv6";
          elsif arch = "Intel 80386" then
             return "i386";
          else

--- a/src/replicant-platform.adb
+++ b/src/replicant-platform.adb
@@ -148,6 +148,8 @@ package body Replicant.Platform is
                when solaris   => return "x86_64";
                when unknown   => return badarch;
             end case;
+         elsif arch (arch'First .. arch'First + 2) = "ARM" then
+            return "armv6";
          elsif arch = "Intel 80386" then
             return "i386";
          else


### PR DESCRIPTION
These patches resolve #75 . I now have a working synth building armv6 packages from an amd64 host.

However, I'm not too happy with the code in "determine_package_architecture"; but with my limited 2 hours of intro to Ada, I wasn't too keen on restructuring.