### PR TITLE
Use handy constant instead literal constant

### DIFF
--- a/src/portscan-packages.adb
+++ b/src/portscan-packages.adb
@@ -891,7 +891,7 @@ package body PortScan.Packages is
    begin
       rank_queue.Iterate (Process => check_port'Access);
       if fail_count > 0 then
-         CLI.Set_Exit_Status (1);
+         CLI.Set_Exit_Status (CLI.Failure);
          TIO.Put (LAT.LF & "A preliminary scan has revealed the cached " &
                  "options of");
          if fail_count = 1 then

--- a/src/replicant.adb
+++ b/src/replicant.adb
@@ -1179,6 +1179,7 @@ package body Replicant is
                if AD.Exists (bootdir) then
                   mount_nullfs (target      => bootdir,
                                 mount_point => location (slave_base, boot));
+                  mount_tmpfs (slave_base & root_boot_fw, 100);
                   mount_tmpfs (slave_base & root_kmodules, 100);
                end if;
             end;
@@ -1298,6 +1299,7 @@ package body Replicant is
             end if;
             if AD.Exists (location (dir_system, boot)) then
                unmount (slave_base & root_kmodules);
+	       unmount (slave_base & root_boot_fw);
                unmount (location (slave_base, boot));
             end if;
             if AD.Exists (location (dir_system, usr_games)) then

--- a/src/replicant.ads
+++ b/src/replicant.ads
@@ -122,6 +122,7 @@ private
    root_var         : constant String := "/var";
    root_home        : constant String := "/home";
    root_boot        : constant String := "/boot";
+   root_boot_fw     : constant String := "/boot/firmware";
    root_kmodules    : constant String := "/boot/modules";
    root_lmodules    : constant String := "/boot/modules.local";
    root_root        : constant String := "/root";


### PR DESCRIPTION
While there's hardly any functional change, I think it's better form to use the constant provided by the Ada.Command_Line package.

For some reason the previous commits persists. I'm probably doing something wrong. Maybe I should've created a branch before comitting.  c0ef2f2 is the commit of interest.