### PR TITLE
CLI.Failure instead of literal constant

### DIFF
--- a/src/portscan-packages.adb
+++ b/src/portscan-packages.adb
@@ -891,7 +891,7 @@ package body PortScan.Packages is
    begin
       rank_queue.Iterate (Process => check_port'Access);
       if fail_count > 0 then
-         CLI.Set_Exit_Status (1);
+         CLI.Set_Exit_Status (CLI.Failure);
          TIO.Put (LAT.LF & "A preliminary scan has revealed the cached " &
                  "options of");
          if fail_count = 1 then


### PR DESCRIPTION
Hardly any functional change, I think it's better form to use the constants supplied from the Ada.Command_Line package.