### PR TITLE
Return TARGET_ARCH and not TARGET for arm64/aarch64

### DIFF
--- a/src/replicant-platform.adb
+++ b/src/replicant-platform.adb
@@ -204,7 +204,7 @@ package body Replicant.Platform is
          elsif arch = "Intel 80386" then
             return "i386";
          elsif arch = "ARM aarch64" then
-            return "arm64";
+            return "aarch64";
          elsif arch = "ARM        " then
             return "armv6";
          else


### PR DESCRIPTION
I found this when trying to cross compile from amd64/amd64 to arm64/aarch64