### PR TITLE
Remove sysutils/htop from list of ports that require linprocfs

### DIFF
--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -823,8 +823,7 @@ package body PortScan is
          all_ports (target).use_procfs := True;
       end if;
       if catport = "emulators/linux_base-c6" or else
-        catport = "emulators/linux_base-f10" or else
-        catport = "sysutils/htop"
+        catport = "emulators/linux_base-f10"
       then
          all_ports (target).use_linprocfs := True;
       end if;
@@ -898,9 +897,6 @@ package body PortScan is
       all_ports (target).scanned := True;
       if catport = "x11/gnustep-gui" then
          all_ports (target).use_procfs := True;
-      end if;
-      if catport = "sysutils/htop" then
-         all_ports (target).use_linprocfs := True;
       end if;
    exception
       when issue : others =>


### PR DESCRIPTION
Since version 2.0, htop no longer requires Linux compatibility so I think it should be removed.

This really isn't a problem by itself, but trying to mount linprocfs on machines without Linux compatibility support causes Synth to hang, so this is a quick fix for such machines with htop installed.

I have removed, in this PR, related code in both populate_port_data_fpc and populate_port_data_npc, but I've only checked with ports collections on FreeBSD 12.1/arm64.