### PR TITLE
Tolerate tabs in multivalued make variables

### DIFF
--- a/src/johnnytext.adb
+++ b/src/johnnytext.adb
@@ -83,6 +83,22 @@ package body JohnnyText is
       return AS.Fixed.Trim (S, AS.Both);
    end trim;
 
+   -----------------
+   --  trimtab #1 --
+   -----------------
+   function trimtab (US : Text) return Text is
+   begin
+      return SU.Trim (US, space_and_HT, space_and_HT);
+   end trimtab;
+
+   -----------------
+   --  trimtab #2 --
+   -----------------
+   function trimtab (S : String) return String is
+   begin
+      return AS.Fixed.Trim (S, space_and_HT, space_and_HT);
+   end trimtab;
+
    ---------------
    --  int2str  --
    ---------------

--- a/src/johnnytext.ads
+++ b/src/johnnytext.ads
@@ -3,11 +3,13 @@
 
 with Ada.Strings.Unbounded;
 with Ada.Strings;
+with Ada.Strings.Maps;
 
 package JohnnyText is
 
-   package AS  renames Ada.Strings;
-   package SU  renames Ada.Strings.Unbounded;
+   package AS renames Ada.Strings;
+   package SU renames Ada.Strings.Unbounded;
+   package SM renames Ada.Strings.Maps;
    subtype Text is SU.Unbounded_String;
    type Line_Markers is private;
 
@@ -26,8 +28,10 @@ package JohnnyText is
    function equivalent (A : Text; B : String) return Boolean;
 
    --  Trim both sides
-   function trim (US : Text) return Text;
-   function trim (S : String) return String;
+   function trim    (US : Text)  return Text;
+   function trim    (S : String) return String;
+   function trimtab (US : Text)  return Text;
+   function trimtab (S : String) return String;
 
    --  unpadded numeric image
    function int2str  (A : Integer) return String;
@@ -108,6 +112,7 @@ package JohnnyText is
 private
 
    single_LF : constant String (1 .. 1) := (1 => ASCII.LF);
+   space_and_HT : constant SM.Character_Set := SM.To_Set (" " & ASCII.HT);
 
    type Line_Markers is
       record

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -540,7 +540,7 @@ package body PortScan is
    is
       subs       : GSS.Slice_Set;
       deps_found : GSS.Slice_Number;
-      trimline   : constant JT.Text := JT.trim (line);
+      trimline   : constant JT.Text := JT.trimtab (line);
       zero_deps  : constant GSS.Slice_Number := GSS.Slice_Number (0);
       dirlen     : constant Natural := dir_ports'Length;
       bracketed  : Natural := 0;
@@ -700,7 +700,7 @@ package body PortScan is
    is
       subs       : GSS.Slice_Set;
       flav_found : GSS.Slice_Number;
-      trimline   : constant JT.Text := JT.trim (line);
+      trimline   : constant JT.Text := JT.trimtab (line);
       zero_flav  : constant GSS.Slice_Number := GSS.Slice_Number (0);
 
       use type GSS.Slice_Number;
@@ -710,7 +710,7 @@ package body PortScan is
       end if;
       GSS.Create (S          => subs,
                   From       => JT.USS (trimline),
-                  Separators => " ",
+                  Separators => " " & LAT.HT,
                   Mode       => GSS.Multiple);
       flav_found :=  GSS.Slice_Count (S => subs);
       if flav_found = zero_flav then


### PR DESCRIPTION
In some cases leading/trailing/separator tabs in multi-valued make
variables are stripped by make, but not by Synth.

This can result in messages like the following:

    Perhaps you intended one of the following port flavors?
       - <port>/<origin>@			<flavor>

Also, variables like RUN_DEPENDS can contain empty variables with
trailing spaces, and this will break Synth's parser:

    RUN_DEPENDS=<tab>${NUMPY}<tab>\

Although empty variables might indicate an issue with port's Makefile,
tools like "portlint" do not report those as warnings.