### PR TITLE
added css to center web report

### DIFF
--- a/www/progress.css
+++ b/www/progress.css
@@ -1,3 +1,8 @@
+html {
+	display: table;
+	margin: auto;
+}
+
 body {
         font-family: Arial, Helvetica, sans-serif;
         font-size: 10pt;
@@ -62,6 +67,8 @@ th, td { border: 1px solid black; }
 #footer {
 	position: fixed;
 	bottom: 0;
+	left: 50%;
+	margin-left: -515px;
 	height: 22px;
 	border-top: 1px solid black;
 }


### PR DESCRIPTION
A little CSS change that centers the web report. See the screenshots for a visual example.

![Screenshot 2021-08-10 at 01-51-52 Synth](https://user-images.githubusercontent.com/14336407/128815133-b3067fa7-f762-4b1f-a516-cb6f2480f825.png)
![Screenshot 2021-08-10 at 01-51-40 Synth](https://user-images.githubusercontent.com/14336407/128815138-616221c0-fffd-47e2-a5cf-947952dc938d.png)

This centers the majority of the content by making the entire `html` block use a table display with `auto` margins, and a pretty common trick is used for the progress bar as a fixed element, where the left of the footer is set to `50%`, then moved back by half the footer length.
