### PR TITLE
Subpackage support (#220)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ external
 
 clear-mount.sh
 Makefile
+
+# windows dev
+ifm/*
+adacurses/*

--- a/src/definitions.ads
+++ b/src/definitions.ads
@@ -6,7 +6,7 @@ package Definitions is
    pragma Pure;
 
    synth_version_major : constant String := "3";
-   synth_version_minor : constant String := "1";
+   synth_version_minor : constant String := "01";
    copyright_years     : constant String := "2015-2024";
    host_localbase      : constant String := "/usr/local";
    host_make           : constant String := "/usr/bin/make";

--- a/src/definitions.ads
+++ b/src/definitions.ads
@@ -6,7 +6,7 @@ package Definitions is
    pragma Pure;
 
    synth_version_major : constant String := "3";
-   synth_version_minor : constant String := "0";
+   synth_version_minor : constant String := "1";
    copyright_years     : constant String := "2015-2024";
    host_localbase      : constant String := "/usr/local";
    host_make           : constant String := "/usr/bin/make";

--- a/src/portscan-packages.ads
+++ b/src/portscan-packages.ads
@@ -49,8 +49,8 @@ package PortScan.Packages is
    --  Returns the value of the stored external repository
    function top_external_repository return String;
 
-   --  Given the full path of a package, query it for the port origin
-   function query_origin (fullpath : String) return String;
+   --  Given the full path of a package, query it for the port origin and version
+   function query_origin_version (fullpath : String) return String;
 
    --  Given the full path of a package plus its port origin, return origin(@flavor)
    function query_full_origin (fullpath, origin : String) return String;
@@ -145,9 +145,9 @@ private
    --  Turn on option and dependency debug checks programmatically
    procedure activate_debugging_code;
 
-   --  Given an origin (already validated) and the name of the package in
-   --  focus, return True if "make -V PKGFILE:T" matches the filename
-   function current_package_name (origin, file_name : String) return Boolean;
+   --  Given an origin (stripped of flavor, already validated) and the version extracted
+   --  from the package, return True if it makes the version in the port Makefile
+   function package_version_matches (origin, version : String) return Boolean;
 
    --  Dedicated progress meter for prescanning packages
    function package_scan_progress return String;

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -773,15 +773,15 @@ package body PortScan is
       command  : constant String :=
                  scanenv & ssroot & " " & chroot_make_program & " -C " & fullport &
                  " -VPKGVERSION -VPKGFILE:T -VMAKE_JOBS_NUMBER -VIGNORE" &
-                 " -VFETCH_DEPENDS_ALL -VEXTRACT_DEPENDS_ALL -VPATCH_DEPENDS_ALL" &
-                 " -VBUILD_DEPENDS_ALL -VLIB_DEPENDS_ALL -VRUN_DEPENDS_ALL" &
+                 " -VFETCH_DEPENDS -VEXTRACT_DEPENDS -VPATCH_DEPENDS" &
+                 " -VBUILD_DEPENDS -VLIB_DEPENDS -VRUN_DEPENDS" &
                  " -VSELECTED_OPTIONS -VDESELECTED_OPTIONS -VUSE_LINUX" &
-                 " -VFLAVORS";
+                 " -VFLAVORS -VLIB_DEPENDS_ALL";
       content  : JT.Text;
       topline  : JT.Text;
       status   : Integer;
 
-      type result_range is range 1 .. 14;
+      type result_range is range 1 .. 15;
 
    begin
       content := Unix.piped_command (command, status);
@@ -818,6 +818,7 @@ package body PortScan is
                   all_ports (target).use_linprocfs := True;
                end if;
             when 14 => populate_flavors (target, topline);
+            when 15 => populate_set_depends (target, catport, topline, build);
          end case;
       end loop;
       all_ports (target).scanned := True;

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -825,8 +825,7 @@ package body PortScan is
       if catport = "x11-toolkits/gnustep-gui" then
          all_ports (target).use_procfs := True;
       end if;
-      if catport = "emulators/linux_base-c6" or else
-        catport = "emulators/linux_base-f10"
+      if catport = "emulators/linux_base-c7"
       then
          all_ports (target).use_linprocfs := True;
       end if;


### PR DESCRIPTION
audio/alsa-plugins subpackages were reverted.
However, this fixes the validation checks for the alsa-plugin main package during repository rebuild.
It also fixes the validation checks for the subpackages.

Hopefully this will better support subpackages when they return.