### PR TITLE
fix flavor-version in package cleanup

### DIFF
--- a/src/portscan-packages.ads
+++ b/src/portscan-packages.ads
@@ -147,7 +147,7 @@ private
 
    --  Given an origin (stripped of flavor, already validated) and the version extracted
    --  from the package, return True if it makes the version in the port Makefile
-   function package_version_matches (origin, version : String) return Boolean;
+   function package_version_matches (origin : String; has_flavor : Boolean; flavor, version : String) return Boolean;
 
    --  Dedicated progress meter for prescanning packages
    function package_scan_progress return String;


### PR DESCRIPTION
When cleaning out packages (e.g., /var/synth/live_packages/All/*), we use `"make ... -C <port-path> -VPKGVERSION"` to get the package version number from the source tree and compare it to the package version number in the built package.  This works fine for unflavored ports, and even for some flavored ports, but fails if the version number for some particular flavor differs from the version number for the default flavor.

To fix this, we need to add "FLAVOR=<flavor>" to the above "make", but only when there is a specific flavor involved.  Do this.

(I noticed the problem when synth kept removing the spirv-llvm-translator-llvm15-15.0.7 package.  Without the FLAVOR=llvm15 argument, the current package version is 19.1.2, which does not match 15.0.7, but with FLAVOR=llvm15, the resulting package version is 15.0.7 as desired.)

The implementation here is clumsy as I am not an Ada programmer. Please clean it up. :-)