### PR TITLE
Speed up tree scan

### DIFF
--- a/default.gpr
+++ b/default.gpr
@@ -6,6 +6,7 @@ project Default is
    for Object_Dir use "build";
    for Main use ("synth.adb");
    for Source_Dirs use (".", "src");
+   for Languages use ("Ada", "C");
 
    package Pretty_Printer is
       for Default_Switches ("ada") use ("-c0", "-pU", "-aU", "-kU");

--- a/src/definitions.ads
+++ b/src/definitions.ads
@@ -6,7 +6,7 @@ package Definitions is
    pragma Pure;
 
    synth_version_major : constant String := "3";
-   synth_version_minor : constant String := "10";
+   synth_version_minor : constant String := "11";
    copyright_years     : constant String := "2015-2025";
    host_localbase      : constant String := "/usr/local";
    host_make           : constant String := "/usr/bin/make";

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -392,12 +392,11 @@ package body PortScan is
       scan_63 : scan (lot => 63);
       scan_64 : scan (lot => 64);
    begin
-      TIO.Put_Line ("Scanning entire ports tree.");
+      TIO.Put_Line (TIO.Standard_Output, "Scanning entire ports tree.");
       while combined_wait loop
          delay 1.0;
          if show_progress then
-            TIO.Put (scan_progress);
-            TIO.Flush;
+            TIO.Put (TIO.Standard_Output, scan_progress);
          end if;
          combined_wait := False;
          for j in scanners'Range loop
@@ -412,7 +411,7 @@ package body PortScan is
       end loop;
       success := not aborted;
       if show_progress then
-         TIO.Put (scan_progress);
+         TIO.Put (TIO.Standard_Output, scan_progress);
       end if;
    end parallel_deep_scan;
 

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -162,6 +162,11 @@ package body PortScan is
          TIO.Put_Line ("... backtrace " & catport);
          fatal := True;
       end if;
+      begin
+         Ada.Directories.Delete_File (filename);
+      exception
+         when others => null;
+      end;
       return not aborted;
 
    end scan_single_port;
@@ -274,7 +279,7 @@ package body PortScan is
          procedure abort_now (culprit, issue_msg, exmsg : String);
 
          temporary_output : constant String :=
-           "/tmp/synth.scanner." & JT.zeropad (2, Natural (lot)) & ".out";
+           "/tmp/synth.scanner." & JT.zeropad (Natural (lot), 2) & ".out";
 
          procedure populate (cursor : subqueue.Cursor)
          is
@@ -392,6 +397,7 @@ package body PortScan is
          delay 1.0;
          if show_progress then
             TIO.Put (scan_progress);
+            TIO.Flush;
          end if;
          combined_wait := False;
          for j in scanners'Range loop
@@ -1643,6 +1649,7 @@ package body PortScan is
       end;
 
       TIO.Put_Line ("Regenerating flavor index: this may take a while ...");
+      TIO.Flush;
       prescan_ports_tree (portsdir);
 
       case software_framework is

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -796,9 +796,9 @@ package body PortScan is
       end get_fullport;
 
       fullport : constant String := get_fullport;
-      ssroot   : constant String := chroot & JT.USS (PM.configuration.dir_buildbase) & ss_base;
-      command  : constant String :=
-                 ssroot & " " & chroot_make_program & " -C " & fullport &
+      command  : constant String := JT.trim (chroot);
+      cmd_args : constant String := JT.USS (PM.configuration.dir_buildbase) & ss_base &
+                 " " & chroot_make_program & " -C " & fullport &
                  " " & cached_var &
                  " -VPKGVERSION -VPKGFILE:T -VMAKE_JOBS_NUMBER -VIGNORE" &
                  " -VFETCH_DEPENDS -VEXTRACT_DEPENDS -VPATCH_DEPENDS" &
@@ -809,7 +809,7 @@ package body PortScan is
 
       type result_range is range 1 .. 15;
    begin
-      if not Unix.external_command (command, filename) then
+      if not Unix.external_command (command, cmd_args, filename) then
          raise bmake_execution with catport & " (check " & filename & ")";
       end if;
 
@@ -878,9 +878,9 @@ package body PortScan is
    is
       catport  : String := get_catport (all_ports (target));
       fullport : constant String := dir_ports & "/" & catport;
-      ssroot   : constant String := chroot & JT.USS (PM.configuration.dir_buildbase) & ss_base;
-      command  : constant String :=
-                 ssroot & " " & chroot_make_program & " -C " & fullport &
+      command  : constant String := JT.trim (chroot);
+      cmd_args  : constant String := JT.USS (PM.configuration.dir_buildbase) & ss_base &
+                 " " & chroot_make_program & " -C " & fullport &
                  " " & cached_var &
                  " .MAKE.EXPAND_VARIABLES=yes" &
                  " -VPKGVERSION -VPKGFILE:T -V_MAKE_JOBS:C/^-j//" &
@@ -891,7 +891,7 @@ package body PortScan is
 
       type result_range is range 1 .. 10;
    begin
-      if not Unix.external_command (command, filename) then
+      if not Unix.external_command (command, cmd_args, filename) then
          raise bmake_execution with catport & " (check " & filename & ")";
       end if;
       begin

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -62,6 +62,7 @@ package body PortScan is
       aborted   : Boolean := False;
       indy500   : Boolean := False;
       uscatport : JT.Text := JT.SUS (catport);
+      filename  : constant String := "/tmp/synth.scanner.09.out";
 
       procedure dig (cursor : block_crate.Cursor)
       is
@@ -73,7 +74,7 @@ package body PortScan is
                raise circular_logic;
             end if;
             if not all_ports (new_target).scanned then
-               populate_port_data (new_target, cache_var);
+               populate_port_data (new_target, cache_var, filename);
                all_ports (new_target).scan_locked := True;
                all_ports (new_target).blocked_by.Iterate (dig'Access);
                all_ports (new_target).scan_locked := False;
@@ -144,7 +145,7 @@ package body PortScan is
             --  This can happen when a dependency is also on the build list.
             return True;
          else
-            populate_port_data (target, cache_var);
+            populate_port_data (target, cache_var, filename);
             all_ports (target).never_remote := always_build;
          end if;
       exception
@@ -272,12 +273,15 @@ package body PortScan is
          procedure populate (cursor : subqueue.Cursor);
          procedure abort_now (culprit, issue_msg, exmsg : String);
 
+         temporary_output : constant String :=
+           "/tmp/synth.scanner." & JT.zeropad (2, Natural (lot)) & ".out";
+
          procedure populate (cursor : subqueue.Cursor)
          is
             target_port : port_index := subqueue.Element (cursor);
          begin
             if not aborted then
-               populate_port_data (target_port, cache_var);
+               populate_port_data (target_port, cache_var, temporary_output);
                mq_progress (lot) := mq_progress (lot) + 1;
             end if;
          exception
@@ -308,6 +312,11 @@ package body PortScan is
          end abort_now;
       begin
          make_queue (lot).Iterate (populate'Access);
+         begin
+            Ada.Directories.Delete_File (temporary_output);
+         exception
+            when others => null;
+         end;
          finished (lot) := True;
       end scan;
 
@@ -746,13 +755,13 @@ package body PortScan is
    --------------------------
    --  populate_port_data  --
    --------------------------
-   procedure populate_port_data (target : port_index; cached_var : String) is
+   procedure populate_port_data (target : port_index; cached_var, filename : String) is
    begin
       case software_framework is
          when ports_collection =>
-            populate_port_data_fpc (target, cached_var);
+            populate_port_data_fpc (target, cached_var, filename);
          when pkgsrc =>
-            populate_port_data_nps (target, cached_var);
+            populate_port_data_nps (target, cached_var, filename);
       end case;
    end populate_port_data;
 
@@ -760,7 +769,7 @@ package body PortScan is
    ------------------------------
    --  populate_port_data_fpc  --
    ------------------------------
-   procedure populate_port_data_fpc (target : port_index; cached_var : String)
+   procedure populate_port_data_fpc (target : port_index; cached_var, filename : String)
    is
       function get_fullport return String;
 
@@ -781,61 +790,67 @@ package body PortScan is
          end if;
       end get_fullport;
 
-      scanenv  : constant String := scan_environment;
       fullport : constant String := get_fullport;
       ssroot   : constant String := chroot & JT.USS (PM.configuration.dir_buildbase) & ss_base;
       command  : constant String :=
-                 scanenv & ssroot & " " & chroot_make_program & " -C " & fullport &
+                 ssroot & " " & chroot_make_program & " -C " & fullport &
                  " " & cached_var &
                  " -VPKGVERSION -VPKGFILE:T -VMAKE_JOBS_NUMBER -VIGNORE" &
                  " -VFETCH_DEPENDS -VEXTRACT_DEPENDS -VPATCH_DEPENDS" &
                  " -VBUILD_DEPENDS -VLIB_DEPENDS -VRUN_DEPENDS" &
                  " -VSELECTED_OPTIONS -VDESELECTED_OPTIONS -VUSE_LINUX" &
                  " -VFLAVORS -VLIB_DEPENDS_ALL";
-      content  : JT.Text;
-      topline  : JT.Text;
-      status   : Integer;
+      handle   : TIO.File_Type;
 
       type result_range is range 1 .. 15;
-
    begin
-      content := Unix.piped_command (command, status);
-      if status /= 0 then
-         raise bmake_execution with catport &
-           " (return code =" & status'Img & ")";
+      if not Unix.external_command (command, filename) then
+         raise bmake_execution with catport & " (check " & filename & ")";
       end if;
 
-      for k in result_range loop
-         JT.nextline (lineblock => content, firstline => topline);
-         case k is
-            when 1 => all_ports (target).port_version := topline;
-            when 2 => all_ports (target).package_name := topline;
-            when 3 =>
-               begin
-                  all_ports (target).jobs :=
-                    builders (Integer'Value (JT.USS (topline)));
-               exception
-                  when others =>
-                     all_ports (target).jobs := PM.configuration.num_builders;
-               end;
-            when 4 => all_ports (target).ignore_reason := topline;
-                      all_ports (target).ignored := not JT.IsBlank (topline);
-            when 5 => populate_set_depends (target, catport, topline, fetch);
-            when 6 => populate_set_depends (target, catport, topline, extract);
-            when 7 => populate_set_depends (target, catport, topline, patch);
-            when 8 => populate_set_depends (target, catport, topline, build);
-            when 9 => populate_set_depends (target, catport, topline, library);
-            when 10 => populate_set_depends (target, catport, topline, runtime);
-            when 11 => populate_set_options (target, topline, True);
-            when 12 => populate_set_options (target, topline, False);
-            when 13 =>
-               if not JT.IsBlank (JT.trim (topline)) then
-                  all_ports (target).use_linprocfs := True;
-               end if;
-            when 14 => populate_flavors (target, topline);
-            when 15 => populate_set_depends (target, catport, topline, build);
-         end case;
-      end loop;
+      begin
+         TIO.Open (handle, TIO.In_File, filename);
+         for k in result_range loop
+            exit when TIO.End_Of_File (handle);
+            declare
+               line : constant String := TIO.Get_Line (handle);
+            begin
+               case k is
+                  when 1 => all_ports (target).port_version := JT.SUS (line);
+                  when 2 => all_ports (target).package_name := JT.SUS (line);
+                  when 3 =>
+                     begin
+                        all_ports (target).jobs := builders (Integer'Value (line));
+                     exception
+                        when others =>
+                           all_ports (target).jobs := PM.configuration.num_builders;
+                     end;
+                  when 4 => all_ports (target).ignore_reason := JT.SUS (line);
+                     all_ports (target).ignored := not JT.IsBlank (line);
+                  when 5 => populate_set_depends (target, catport, JT.SUS (line), fetch);
+                  when 6 => populate_set_depends (target, catport, JT.SUS (line), extract);
+                  when 7 => populate_set_depends (target, catport, JT.SUS (line), patch);
+                  when 8 => populate_set_depends (target, catport, JT.SUS (line), build);
+                  when 9 => populate_set_depends (target, catport, JT.SUS (line), library);
+                  when 10 => populate_set_depends (target, catport, JT.SUS (line), runtime);
+                  when 11 => populate_set_options (target, JT.SUS (line), True);
+                  when 12 => populate_set_options (target, JT.SUS (line), False);
+                  when 15 => populate_set_depends (target, catport,  JT.SUS (line), build);
+                  when 14 => populate_flavors (target,  JT.SUS (line));
+                  when 13 =>
+                     if not JT.IsBlank (JT.trim (line)) then
+                        all_ports (target).use_linprocfs := True;
+                     end if;
+               end case;
+            end;
+         end loop;
+         TIO.Close (handle);
+      exception
+         when others =>
+            if TIO.Is_Open (handle) then
+               TIO.Close (handle);
+            end if;
+      end;
       all_ports (target).scanned := True;
       if catport = "x11-toolkits/gnustep-gui" then
          all_ports (target).use_procfs := True;
@@ -854,65 +869,69 @@ package body PortScan is
    ------------------------------
    --  populate_port_data_nps  --
    ------------------------------
-   procedure populate_port_data_nps (target : port_index; cached_var : String)
+   procedure populate_port_data_nps (target : port_index; cached_var, filename : String)
    is
       catport  : String := get_catport (all_ports (target));
       fullport : constant String := dir_ports & "/" & catport;
-      scanenv  : constant String := scan_environment;
-      ssroot   : constant String := chroot &
-                 JT.USS (PM.configuration.dir_buildbase) & ss_base;
+      ssroot   : constant String := chroot & JT.USS (PM.configuration.dir_buildbase) & ss_base;
       command  : constant String :=
-                 scanenv & ssroot & " " & chroot_make_program & " -C " & fullport &
+                 ssroot & " " & chroot_make_program & " -C " & fullport &
                  " " & cached_var &
                  " .MAKE.EXPAND_VARIABLES=yes" &
                  " -VPKGVERSION -VPKGFILE:T -V_MAKE_JOBS:C/^-j//" &
                  " -V_CBBH_MSGS -VTOOL_DEPENDS -VBUILD_DEPENDS -VDEPENDS" &
                  " -VPKG_OPTIONS -VPKG_DISABLED_OPTIONS" &
                  " -VEMUL_PLATFORMS";
-      content  : JT.Text;
-      topline  : JT.Text;
-      status   : Integer;
+      handle   : TIO.File_Type;
 
       type result_range is range 1 .. 10;
    begin
-      content := Unix.piped_command (command, status);
-      if status /= 0 then
-         raise bmake_execution with catport &
-           " (return code =" & status'Img & ")";
+      if not Unix.external_command (command, filename) then
+         raise bmake_execution with catport & " (check " & filename & ")";
       end if;
-      for k in result_range loop
-         JT.nextline (lineblock => content, firstline => topline);
-         case k is
-            when 1 => all_ports (target).port_version := topline;
-            when 2 => all_ports (target).package_name := topline;
-            when 3 =>
-               if JT.IsBlank (topline) then
-                  all_ports (target).jobs := PM.configuration.num_builders;
-               else
-                  begin
-                     all_ports (target).jobs :=
-                       builders (Integer'Value (JT.USS (topline)));
-                  exception
-                     when others =>
-                        all_ports (target).jobs :=
-                          PM.configuration.num_builders;
-                  end;
-               end if;
-            when 4 =>
-               all_ports (target).ignore_reason :=
-                 clean_up_pkgsrc_ignore_reason (JT.USS (topline));
-               all_ports (target).ignored := not JT.IsBlank (topline);
-            when 5 => populate_set_depends (target, catport, topline, build);
-            when 6 => populate_set_depends (target, catport, topline, build);
-            when 7 => populate_set_depends (target, catport, topline, runtime);
-            when 8 => populate_set_options (target, topline, True);
-            when 9 => populate_set_options (target, topline, False);
-            when 10 =>
-               if JT.contains (topline, "linux") then
-                  all_ports (target).use_linprocfs := True;
-               end if;
-         end case;
-      end loop;
+      begin
+         TIO.Open (handle, TIO.In_File, filename);
+         for k in result_range loop
+            exit when TIO.End_Of_File (handle);
+            declare
+               line : constant String := TIO.Get_Line (handle);
+            begin
+               case k is
+                  when 1 => all_ports (target).port_version := JT.SUS (line);
+                  when 2 => all_ports (target).package_name := JT.SUS (line);
+                  when 3 =>
+                     if JT.IsBlank (line) then
+                        all_ports (target).jobs := PM.configuration.num_builders;
+                     else
+                        begin
+                           all_ports (target).jobs := builders (Integer'Value (line));
+                        exception
+                           when others =>
+                              all_ports (target).jobs := PM.configuration.num_builders;
+                        end;
+                     end if;
+                  when 4 =>
+                     all_ports (target).ignore_reason := clean_up_pkgsrc_ignore_reason (line);
+                     all_ports (target).ignored := not JT.IsBlank (line);
+                  when 5 => populate_set_depends (target, catport, JT.SUS (line), build);
+                  when 6 => populate_set_depends (target, catport, JT.SUS (line), build);
+                  when 7 => populate_set_depends (target, catport, JT.SUS (line), runtime);
+                  when 8 => populate_set_options (target, JT.SUS (line), True);
+                  when 9 => populate_set_options (target, JT.SUS (line), False);
+                  when 10 =>
+                     if JT.contains (line, "linux") then
+                        all_ports (target).use_linprocfs := True;
+                     end if;
+               end case;
+            end;
+         end loop;
+         TIO.Close (handle);
+      exception
+         when others =>
+            if TIO.Is_Open (handle) then
+               TIO.Close (handle);
+            end if;
+      end;
       all_ports (target).scanned := True;
       if catport = "x11/gnustep-gui" then
          all_ports (target).use_procfs := True;
@@ -1206,7 +1225,7 @@ package body PortScan is
    --------------------------
    function get_max_lots return scanners
    is
-      first_try : constant Positive := Positive (number_cores) * 3;
+      first_try : constant Positive := Positive (number_cores) * 2;
    begin
       if first_try > Positive (scanners'Last) then
          return scanners'Last;

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -1230,8 +1230,20 @@ package body PortScan is
    --------------------------
    function get_max_lots return scanners
    is
-      first_try : constant Positive := Positive (number_cores) * 3;
+      first_try : Positive;
    begin
+      case number_cores is
+         when 1 => first_try := 1;
+         when 2 => first_try := 3;
+         when 3 => first_try := 4;
+         when others =>
+            first_try := Positive (number_cores);
+            if number_cores mod 2 = 0 then
+               first_try := first_try + Positive (first_try / 2);
+            else
+               first_try := first_try + Positive ((first_try - 1) / 2);
+            end if;
+      end case;
       if first_try > Positive (scanners'Last) then
          return scanners'Last;
       else

--- a/src/portscan.adb
+++ b/src/portscan.adb
@@ -392,11 +392,11 @@ package body PortScan is
       scan_63 : scan (lot => 63);
       scan_64 : scan (lot => 64);
    begin
-      TIO.Put_Line (TIO.Standard_Output, "Scanning entire ports tree.");
+      TIO.Put_Line ("Scanning entire ports tree.");
       while combined_wait loop
          delay 1.0;
          if show_progress then
-            TIO.Put (TIO.Standard_Output, scan_progress);
+            TIO.Put (scan_progress);
          end if;
          combined_wait := False;
          for j in scanners'Range loop
@@ -411,7 +411,7 @@ package body PortScan is
       end loop;
       success := not aborted;
       if show_progress then
-         TIO.Put (TIO.Standard_Output, scan_progress);
+         TIO.Put (scan_progress);
       end if;
    end parallel_deep_scan;
 
@@ -1230,7 +1230,7 @@ package body PortScan is
    --------------------------
    function get_max_lots return scanners
    is
-      first_try : constant Positive := Positive (number_cores) * 2;
+      first_try : constant Positive := Positive (number_cores) * 3;
    begin
       if first_try > Positive (scanners'Last) then
          return scanners'Last;
@@ -1648,7 +1648,6 @@ package body PortScan is
       end;
 
       TIO.Put_Line ("Regenerating flavor index: this may take a while ...");
-      TIO.Flush;
       prescan_ports_tree (portsdir);
 
       case software_framework is

--- a/src/portscan.ads
+++ b/src/portscan.ads
@@ -43,9 +43,12 @@ package PortScan is
    --  Starting with a single port, recurse to determine a limited but complete
    --  dependency tree.  Repeated calls will augment already existing data.
    --  Return True on success
-   function scan_single_port (catport : String; always_build : Boolean;
-                              fatal : out Boolean)
-                              return Boolean;
+   function scan_single_port
+     (catport      : String;
+      always_build : Boolean;
+      cache_var    : String;
+      fatal        : out Boolean)
+      return Boolean;
 
    --  This procedure causes the reverse dependencies to be calculated, and
    --  then the extended (recursive) reverse dependencies.  The former is
@@ -230,9 +233,9 @@ private
                                    on      : Boolean);
    procedure populate_flavors     (target  : port_index;
                                    line    : JT.Text);
-   procedure populate_port_data   (target : port_index);
-   procedure populate_port_data_fpc (target : port_index);
-   procedure populate_port_data_nps (target : port_index);
+   procedure populate_port_data     (target : port_index; cached_var : String);
+   procedure populate_port_data_fpc (target : port_index; cached_var : String);
+   procedure populate_port_data_nps (target : port_index; cached_var : String);
    procedure drill_down (next_target     : port_index;
                          original_target : port_index);
 
@@ -242,8 +245,10 @@ private
    procedure grep_Makefile (portsdir, category : String);
    procedure walk_all_subdirectories (portsdir, category : String);
    procedure wipe_make_queue;
-   procedure parallel_deep_scan (success : out Boolean;
-                                 show_progress : Boolean);
+   procedure parallel_deep_scan
+     (success       : out Boolean;
+      show_progress : Boolean;
+      cache_var     : String);
 
    --  some helper routines
    function scan_environment return String;
@@ -253,6 +258,7 @@ private
    function scan_progress return String;
    function get_max_lots return scanners;
    function get_pkg_name (origin : String) return String;
+   function set_port_cache_variables return String;
    function timestamp (hack : CAL.Time; www_format : Boolean := False) return String;
    function clean_up_pkgsrc_ignore_reason (dirty_string : String) return JT.Text;
    function subdirectory_is_older (portsdir, category : String;

--- a/src/portscan.ads
+++ b/src/portscan.ads
@@ -233,9 +233,9 @@ private
                                    on      : Boolean);
    procedure populate_flavors     (target  : port_index;
                                    line    : JT.Text);
-   procedure populate_port_data     (target : port_index; cached_var : String);
-   procedure populate_port_data_fpc (target : port_index; cached_var : String);
-   procedure populate_port_data_nps (target : port_index; cached_var : String);
+   procedure populate_port_data     (target : port_index; cached_var, filename : String);
+   procedure populate_port_data_fpc (target : port_index; cached_var, filename : String);
+   procedure populate_port_data_nps (target : port_index; cached_var, filename : String);
    procedure drill_down (next_target     : port_index;
                          original_target : port_index);
 

--- a/src/synexec.c
+++ b/src/synexec.c
@@ -1,0 +1,154 @@
+/*
+ * This file is covered by the Internet Software Consortium (ISC) License
+ * Reference: /License.txt
+ *
+ * This provides a shell-free alternative the popen piped command mechanism.
+ * The output is written to a file.
+ */
+
+#ifndef _WIN32
+
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/wait.h>
+#ifndef __unused
+#define __unused __attribute__((__unused__))
+#endif
+#ifndef W_EXITCODE
+#define W_EXITCODE(ret, sig)	((ret) << 8 | (sig))
+#endif
+
+
+/*
+ * --------------------------
+ * --  diagnostic_message  --
+ * --------------------------
+ */
+static void
+diagnostic_message (int fd, char *prog, int argc, char *argv[])
+{
+   write (fd, "Command execution failed: ", 26);
+   write (fd, prog, strlen (prog));
+   write (fd, "\n               arguments:", 26);
+   for (int x = 0; x < argc; x++) {
+      write (fd, " ", 1);
+      write (fd, argv[x], strlen (argv[x]));
+   }
+   write (fd, "\n", 1);
+}
+
+
+/*
+ * --------------------------
+ * --  start_new_log_file  --
+ * --------------------------
+ */
+int
+start_new_log_file (const char *path)
+{
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+
+   return (open (path, flags, 0644));
+}
+
+
+/*
+ * ---------------
+ * --  synexec  --
+ * ---------------
+ * argument fd      : file description to open log file
+ * argument prog    : full path to program to execute
+ * argument argc    : number of arguments to pass to program
+ * argument argv    : vector of arguments to pass to program
+ *
+ * return code  pid : success   (positive number)
+ *               -1 : negative file descriptor
+ *               -2 : file descriptor below standard error
+ *               -3 : first fork failed
+ *               -4 : second fork failed
+ *               -5 : setsid failed
+ *               -6 : execv failed
+ */
+int
+synexec (int fd, char *prog, int argc, char *argv[])
+{
+  pid_t fork1_pid;
+  pid_t fork2_pid;
+  pid_t child_pid;
+  pid_t wait_result;
+  int grand_status = 0;
+
+  if (fd < 0)
+    {
+      return (-1);
+    }
+  if (fd <= STDERR_FILENO)
+    {
+      return (-2);
+    }
+
+  fork1_pid = fork();
+  if (fork1_pid < 0)
+    {
+      return (-3);
+    }
+
+
+  /***************************
+   *  First fork successful  *
+   ***************************/
+  if (fork1_pid == 0)
+    {
+      /* child of fork #1 */
+      child_pid = getpid();
+      if (setsid() < 0)
+        {
+          _exit (-5);
+        }
+      signal(SIGINT, SIG_IGN);
+
+      fork2_pid = fork();
+      if (fork2_pid < 0)
+        {
+          _exit (-4);
+        }
+
+
+      /****************************
+       *  Second fork successful  *
+       ****************************/
+      if (fork2_pid == 0)
+        {
+          /* grandchild */
+
+          dup2 (fd, STDOUT_FILENO);
+          dup2 (fd, STDERR_FILENO);
+
+          execv (prog, argv);
+
+          /* execv doesn't normally return, so command failed to execute */
+          diagnostic_message(fd, prog, argc, argv);
+          _exit (-6);
+        }
+
+      /* parent of grandchild (a.k.a child) */
+      wait_result = waitpid (fork2_pid, &grand_status, 0);
+      if (wait_result < 0)
+        {
+          grand_status = W_EXITCODE(1, 0);
+        };
+
+      _exit (WEXITSTATUS (grand_status));
+    }
+
+  /* Parent of fork #1 */
+  return fork1_pid;
+}
+
+
+#endif /* __WIN32 */

--- a/src/unix.adb
+++ b/src/unix.adb
@@ -109,6 +109,29 @@ package body Unix is
    end external_command;
 
 
+   ------------------------
+   --  external_command  --
+   ------------------------
+   function external_command (command     : String;
+                              output_file : String) return Boolean
+   is
+      Args        : OSL.Argument_List_Access;
+      Exit_Status : Integer;
+      success     : Boolean;
+   begin
+      Args := OSL.Argument_String_To_List (command);
+      OSL.Spawn
+        (Program_Name => Args (Args'First).all,
+         Args         => Args (Args'First + 1 .. Args'Last),
+         Output_File  => output_file,
+         Success      => success,
+         Return_Code  => Exit_Status,
+         Err_To_Out   => True);
+      OSL.Free (Args);
+      return Exit_Status = 0;
+   end external_command;
+
+
    -------------------
    --  fork_failed  --
    -------------------

--- a/src/unix.adb
+++ b/src/unix.adb
@@ -119,11 +119,10 @@ package body Unix is
       argvector : aliased struct_argv;
       cprogram  : ICS.chars_ptr;
       num_args  : IC.int;
-      pid_res   : IC.int;
+      retcode   : IC.int;
       cfd       : IC.int;
       close_res : IC.int;
       log_fd    : File_Descriptor;
-      status    : process_exit;
 
       use type IC.int;
       pragma Unreferenced (close_res);
@@ -133,7 +132,7 @@ package body Unix is
       log_fd := start_new_log (output_file);
       cfd := IC.int (log_fd);
 
-      pid_res := synexec (cfd, cprogram, num_args, argvector'Unchecked_Access);
+      retcode := synexec (cfd, cprogram, num_args, argvector'Unchecked_Access);
 
       close_res := C_Close (cfd);
       if num_args > 0 then
@@ -143,20 +142,7 @@ package body Unix is
       end if;
       ICS.Free (cprogram);
 
-      if pid_res < 0 then
-         return False;  --  fork failed?  6 possible errors, check code
-      end if;
-
-      loop
-         delay 0.05;
-         status := process_status (pid_t (pid_res));
-         if status = exited_normally then
-            return True;
-         end if;
-         if status = exited_with_error then
-            return False;
-         end if;
-      end loop;
+      return retcode = 0;
    end external_command;
 
 

--- a/src/unix.ads
+++ b/src/unix.ads
@@ -28,6 +28,11 @@ package Unix is
    --  Returns "True" on success
    function external_command (command : String) return Boolean;
 
+   --  Spawn command, writing stdout+stderr to the output file
+   --  Returns "True" on success
+   function external_command (command     : String;
+                              output_file : String) return Boolean;
+
    --  wrapper for nonblocking spawn
    function launch_process (command : String) return pid_t;
 

--- a/src/unix_core.c
+++ b/src/unix_core.c
@@ -10,6 +10,8 @@
  *    2 when process exited with error
  */
 
+#ifndef _WIN32
+
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <termios.h>
@@ -104,7 +106,7 @@ __ignore_background_tty_writes ()
    prev_val = signal(SIGTTOU, SIG_IGN);
 
    /* return 1 on failure, 0 on success */
-   return (prev_val == SIG_ERR); 
+   return (prev_val == SIG_ERR);
 }
 
 /*
@@ -117,5 +119,7 @@ __ignore_background_tty_reads ()
    prev_val = signal(SIGTTIN, SIG_IGN);
 
    /* return 1 on failure, 0 on success */
-   return (prev_val == SIG_ERR); 
+   return (prev_val == SIG_ERR);
 }
+
+#endif


### PR DESCRIPTION
Mainly this branch revamps how the entire scan is scanned, greatly reducing the time.

on a core i5:
CPU: Intel(R) Core(TM) i5-3470 CPU @ 3.20GHz (3192.90-MHz K8-class CPU)

The ports tree scan (flavor index generation) was reduced from:
```
12:17.22 elapsed time (101.1%) 
```
to
```
3:50.36 elapsed time (389.7%) 
```

That's more than an 8 minute reduction ((737 - 230)/737 = 69% reduction