### PR TITLE
make host's /etc/hosts file available in jails - fixes #246

### DIFF
--- a/src/replicant.adb
+++ b/src/replicant.adb
@@ -812,6 +812,21 @@ package body Replicant is
    end copy_resolv_conf;
 
 
+   ------------------------
+   --  copy_hosts  --
+   ------------------------
+   procedure copy_hosts (path_to_etc : String)
+   is
+      original : constant String := "/etc/hosts";
+   begin
+      if not AD.Exists (original) then
+         return;
+      end if;
+      AD.Copy_File (Source_Name => original,
+                    Target_Name => path_to_etc & "/hosts");
+   end copy_hosts;
+
+
    -----------------------
    --  copy_rc_default  --
    -----------------------
@@ -1272,6 +1287,7 @@ package body Replicant is
       copy_mtree_files    (location (slave_base, etc_mtree));
       copy_rc_default     (location (slave_base, etc));
       copy_resolv_conf    (location (slave_base, etc));
+      copy_hosts          (location (slave_base, etc));
       create_make_conf    (location (slave_base, etc), opts.skip_cwrappers);
       create_passwd       (location (slave_base, etc));
       create_group        (location (slave_base, etc));

--- a/src/replicant.ads
+++ b/src/replicant.ads
@@ -202,6 +202,9 @@ private
    --  copy host's /etc/resolv.conf to slave
    procedure copy_resolv_conf (path_to_etc : String);
 
+   --  copy host's /etc/hosts to slave
+   procedure copy_hosts (path_to_etc : String);
+
    --  copy host's /etc/mtree files to slave
    procedure copy_mtree_files (path_to_mtree : String);
 


### PR DESCRIPTION
As noted in #246, building mod_perl2 can fail in synth if the package's network tests cannot resolve ```localhost```. This PR resolves the issue by amending the ```launch_slave``` procedure to copy the host's ```/etc/hosts``` file into the ```etc``` directory within jails. A new ```copy_hosts``` procedure modelled on ```copy_resolv_conf``` is introduced for this purpose.